### PR TITLE
[RHPAM-3330] replicas fixes

### DIFF
--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -646,10 +646,10 @@ func serverSortBlanks(serverSets []api.KieServerSet) []api.KieServerSet {
 // or a specific one.
 func getServersConfig(cr *api.KieApp) ([]api.ServerTemplate, error) {
 	var servers []api.ServerTemplate
-	serverReplicas := Pint32(1)
+	serverReplicas := int32(1)
 	envConstants, hasEnv := constants.EnvironmentConstants[cr.Status.Applied.Environment]
 	if hasEnv {
-		serverReplicas = &envConstants.Replica.Server.Replicas
+		serverReplicas = envConstants.Replica.Server.Replicas
 	}
 	product := GetProduct(cr.Status.Applied.Environment)
 	usedNames := map[string]bool{}
@@ -696,13 +696,12 @@ func getServersConfig(cr *api.KieApp) ([]api.ServerTemplate, error) {
 			}
 
 			// Set replicas
-			jbpmReplicas := int32(2)
-			if serverSet.JbpmCluster && *serverReplicas < jbpmReplicas {
-				// in case of wrong input we set at least two
-				serverReplicas = &jbpmReplicas
-			}
 			if serverSet.Replicas == nil {
-				serverSet.Replicas = serverReplicas
+				serverSet.Replicas = &serverReplicas
+			}
+			// If JbpmCluster enabled and replicas set to 1, increase replicas to 2.
+			if serverSet.JbpmCluster && *serverSet.Replicas == int32(1) {
+				serverSet.Replicas = Pint32(2)
 			}
 			template.Replicas = *serverSet.Replicas
 

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -5458,11 +5458,23 @@ func TestRhdmProdImmutableEnvironmentWithJbpmClusterEnabled(t *testing.T) {
 	assert.Equal(t, int32(2), env.Servers[0].DeploymentConfigs[0].Spec.Replicas)
 	assert.Nil(t, cr.Status.Applied.Objects.Console, "Console should be nil")
 
+	cr.Spec.Objects.Servers[0].Replicas = Pint32(0)
+	env, err = GetEnvironment(cr, test.MockService())
+	assert.Nil(t, err, "Error getting prod environment")
+	assert.True(t, cr.Status.Applied.Objects.Servers[0].JbpmCluster)
+	assert.Equal(t, int32(0), env.Servers[0].DeploymentConfigs[0].Spec.Replicas, "a replica setting of zero in spec should not be overriden")
+
 	cr.Spec.Objects.Servers[0].Replicas = Pint32(1)
 	env, err = GetEnvironment(cr, test.MockService())
 	assert.Nil(t, err, "Error getting prod environment")
 	assert.True(t, cr.Status.Applied.Objects.Servers[0].JbpmCluster)
-	assert.Equal(t, int32(1), env.Servers[0].DeploymentConfigs[0].Spec.Replicas, "a user's setting in spec should not be overriden")
+	assert.Equal(t, int32(2), env.Servers[0].DeploymentConfigs[0].Spec.Replicas, "a user's setting in spec should only be overridden if set to 1")
+
+	cr.Spec.Objects.Servers[0].Replicas = Pint32(3)
+	env, err = GetEnvironment(cr, test.MockService())
+	assert.Nil(t, err, "Error getting prod environment")
+	assert.True(t, cr.Status.Applied.Objects.Servers[0].JbpmCluster)
+	assert.Equal(t, int32(3), env.Servers[0].DeploymentConfigs[0].Spec.Replicas, "a user's setting in spec should only be overridden if set to 1")
 }
 
 func TestRhdmProdImmutableEnvironmentWithJbpmClusterDisabled(t *testing.T) {


### PR DESCRIPTION
switch to increasing replicas to 2 ONLY in the event that they are currently set to 1 and JbpmCluster is set to true. otherwise, for example, if replicas is set to 0... that setting should be honored.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>